### PR TITLE
Apply prettier to gh-pages

### DIFF
--- a/_posts/2015-12-11-error-correcting-codes.md
+++ b/_posts/2015-12-11-error-correcting-codes.md
@@ -35,7 +35,7 @@ Suppose that I intend to send the following message to a
 friend through a noisy channel: `Hi!` [^2] This string is
 equivalent to the bits: `010010000110100100100001`
 
-However, my friend may receive this message as corrupted [in ASCII](https://www.rapidtables.com/convert/number/binary-to-string.html). 
+However, my friend may receive this message as corrupted [in ASCII](https://www.rapidtables.com/convert/number/binary-to-string.html).
 Flipped bits are marked in $\textcolor{red}{\verb|red|}$.
 
 <p class="center">

--- a/_posts/2023-08-01-cc-simulations.md
+++ b/_posts/2023-08-01-cc-simulations.md
@@ -1,12 +1,12 @@
 ---
 title: "C++ simulations in the browser"
 categories:
-- research
-- design
-- engineering
+  - research
+  - design
+  - engineering
 tags:
-- "c++"
-- computer-graphics
+  - "c++"
+  - computer-graphics
 layout: post
 description: ""
 image: "https://p13i.io/assets/2023-08-01-cc-simulations-thumbnail.jpg"


### PR DESCRIPTION
This pull request applies NPM's `prettier` formatting changes to the codebase at c98f4bbd8bfd4cd15aee111be2cbf0e19203d813.