### PR TITLE
Apply prettier to gh-pages

### DIFF
--- a/_includes/_javascripts.html
+++ b/_includes/_javascripts.html
@@ -11,13 +11,18 @@
   src="/static/js/lazyload.min.js"
 ></script>
 <!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-2Q1HVMYX6L"></script>
+<script
+  async
+  src="https://www.googletagmanager.com/gtag/js?id=G-2Q1HVMYX6L"
+></script>
 <script>
   window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
+  function gtag() {
+    dataLayer.push(arguments);
+  }
+  gtag("js", new Date());
 
-  gtag('config', 'G-2Q1HVMYX6L');
+  gtag("config", "G-2Q1HVMYX6L");
 </script>
 
 <!-- KaTeX: LaTeX typesetting for the web by Khan Academy -->


### PR DESCRIPTION
This pull request applies NPM's `prettier` formatting changes to the codebase at 53b31982811312269c8ed04a9e2aaf279f622747.