### PR TITLE
Apply prettier to no-doctype

### DIFF
--- a/_includes/_gallery.html
+++ b/_includes/_gallery.html
@@ -1,648 +1,622 @@
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta
-      name="viewport"
-      content="width=device-width,initial-scale=1"
-    />
-    <title>Gallery</title>
-    <style>
-      :root {
-        --jg-spacing: 42px;
-        --jg-max-width: 1200px;
-      }
-      html,
-      body {
-        height: 100%;
-        margin: 0;
-        font-family:
-          system-ui,
-          -apple-system,
-          Segoe UI,
-          Roboto,
-          "Helvetica Neue",
-          Arial;
-      }
-      .jg-wrap {
-        max-width: var(--jg-max-width);
-        margin: 20px auto;
-        padding: 12px;
-        box-sizing: border-box;
-      }
-      .jg-row {
-        display: flex;
-        gap: var(--jg-spacing);
-        margin-bottom: var(--jg-spacing);
-        align-items: stretch;
-      }
-      .jg-row:last-child {
-        margin-bottom: 0;
-      }
-      .jg-row img {
-        display: block;
-        object-fit: cover;
-        --intrinsic-w: auto;
-        --intrinsic-h: auto;
-      }
-      /* make images non-selectable while dragging */
-      .jg-row img {
-        user-select: none;
-        -webkit-user-drag: none;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="jg-wrap">
-      <!-- Server-side fallback rows (JS will reflow into responsive layout at runtime) -->
-      <div id="justified-gallery-container">
-        <div class="jg-row">
-          <img
-            src="https://p13i.io/assets/pix/IMG_7561-EFFECTS.jpg"
-            width="330"
-            height="248"
-            data-w="4032"
-            data-h="3024"
-            alt="IMG_7561-EFFECTS.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://user-images.githubusercontent.com/13140065/155825868-6ada81bf-69c0-404e-ad28-41fec88c3781.jpg"
-            width="248"
-            height="248"
-            data-w="512"
-            data-h="512"
-            alt="155825868-6ada81bf-69c0-404e-ad28-41fec88c3781.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://user-images.githubusercontent.com/13140065/155815967-0968cbf1-2d06-470a-9fc2-7d3b88493cd9.jpg"
-            width="248"
-            height="248"
-            data-w="512"
-            data-h="512"
-            alt="155815967-0968cbf1-2d06-470a-9fc2-7d3b88493cd9.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://user-images.githubusercontent.com/13140065/155812212-3cf879df-b300-4c53-aacb-b30caa926221.jpg"
-            width="248"
-            height="248"
-            data-w="512"
-            data-h="512"
-            alt="155812212-3cf879df-b300-4c53-aacb-b30caa926221.jpg"
-            loading="lazy"
-          />
-        </div>
-        <div class="jg-row">
-          <img
-            src="https://raw.githubusercontent.com/p13i/assets/main/2024-12-20-607c.jpg"
-            width="206"
-            height="206"
-            data-w="1600"
-            data-h="1600"
-            alt="2024-12-20-607c.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/2024-12-21-4c7b.jpg"
-            width="206"
-            height="206"
-            data-w="3000"
-            data-h="3000"
-            alt="2024-12-21-4c7b.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/2024-12-21-df84.jpg"
-            width="206"
-            height="206"
-            data-w="1600"
-            data-h="1600"
-            alt="2024-12-21-df84.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/2024-12-21-7019.jpg"
-            width="206"
-            height="206"
-            data-w="2048"
-            data-h="2048"
-            alt="2024-12-21-7019.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/pix/2024-12-22-58af.jpg"
-            width="206"
-            height="206"
-            data-w="2048"
-            data-h="2048"
-            alt="2024-12-22-58af.jpg"
-            loading="lazy"
-          />
-        </div>
-        <div class="jg-row">
-          <img
-            src="https://p13i.io/assets/pix/2024-12-22-5b4d.jpg"
-            width="206"
-            height="206"
-            data-w="2048"
-            data-h="2048"
-            alt="2024-12-22-5b4d.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/pix/2024-12-22-f17f.jpg"
-            width="206"
-            height="206"
-            data-w="2840"
-            data-h="2840"
-            alt="2024-12-22-f17f.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/2025-02-01-33c3.jpg"
-            width="206"
-            height="206"
-            data-w="2048"
-            data-h="2048"
-            alt="2025-02-01-33c3.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/2025-02-12-3680.jpg"
-            width="206"
-            height="206"
-            data-w="3024"
-            data-h="3024"
-            alt="2025-02-12-3680.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/2025-02-27-f1d1.jpg"
-            width="206"
-            height="206"
-            data-w="2587"
-            data-h="2587"
-            alt="2025-02-27-f1d1.jpg"
-            loading="lazy"
-          />
-        </div>
-        <div class="jg-row">
-          <img
-            src="https://p13i.io/assets/2025-04-19-4940.jpg"
-            width="206"
-            height="206"
-            data-w="2048"
-            data-h="2048"
-            alt="2025-04-19-4940.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/2025-05-25-8df0.jpg"
-            width="206"
-            height="206"
-            data-w="1600"
-            data-h="1600"
-            alt="2025-05-25-8df0.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/2025-05-25-0810.jpg"
-            width="206"
-            height="206"
-            data-w="2048"
-            data-h="2048"
-            alt="2025-05-25-0810.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/2025-05-25-5342.jpg"
-            width="206"
-            height="206"
-            data-w="1911"
-            data-h="1911"
-            alt="2025-05-25-5342.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/2025-06-19-5414.jpg"
-            width="206"
-            height="206"
-            data-w="2900"
-            data-h="2900"
-            alt="2025-06-19-5414.jpg"
-            loading="lazy"
-          />
-        </div>
-        <div class="jg-row">
-          <img
-            src="https://p13i.io/assets/2025-08-21-3834.jpg"
-            width="267"
-            height="200"
-            data-w="3000"
-            data-h="2250"
-            alt="2025-08-21-3834.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/2025-08-21-22ae.jpg"
-            width="891"
-            height="200"
-            data-w="2048"
-            data-h="461"
-            alt="2025-08-21-22ae.jpg"
-            loading="lazy"
-          />
-        </div>
-        <div class="jg-row">
-          <img
-            src="https://p13i.io/assets/2025-09-08-3a6f.jpg"
-            width="206"
-            height="206"
-            data-w="1600"
-            data-h="1600"
-            alt="2025-09-08-3a6f.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/2025-09-08-445c.jpg"
-            width="206"
-            height="206"
-            data-w="2048"
-            data-h="2048"
-            alt="2025-09-08-445c.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/2025-09-08-4c03.jpg"
-            width="206"
-            height="206"
-            data-w="2055"
-            data-h="2055"
-            alt="2025-09-08-4c03.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/2025-09-08-4c61.jpg"
-            width="206"
-            height="206"
-            data-w="2048"
-            data-h="2048"
-            alt="2025-09-08-4c61.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/2025-09-08-6c8e.jpg"
-            width="206"
-            height="206"
-            data-w="1600"
-            data-h="1600"
-            alt="2025-09-08-6c8e.jpg"
-            loading="lazy"
-          />
-        </div>
-        <div class="jg-row">
-          <img
-            src="https://p13i.io/assets/2025-09-08-8baf.jpg"
-            width="206"
-            height="206"
-            data-w="2545"
-            data-h="2545"
-            alt="2025-09-08-8baf.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/2025-09-08-a417.jpg"
-            width="208"
-            height="206"
-            data-w="2212"
-            data-h="2196"
-            alt="2025-09-08-a417.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/2025-09-08-0b70.jpg"
-            width="206"
-            height="206"
-            data-w="1600"
-            data-h="1600"
-            alt="2025-09-08-0b70.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/2025-09-08-11ff.jpg"
-            width="206"
-            height="206"
-            data-w="2048"
-            data-h="2048"
-            alt="2025-09-08-11ff.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/2025-09-08-61eb.jpg"
-            width="206"
-            height="206"
-            data-w="2048"
-            data-h="2048"
-            alt="2025-09-08-61eb.jpg"
-            loading="lazy"
-          />
-        </div>
-        <div class="jg-row">
-          <img
-            src="https://p13i.io/assets/2025-09-08-39e1.jpg"
-            width="206"
-            height="206"
-            data-w="2458"
-            data-h="2458"
-            alt="2025-09-08-39e1.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/2025-09-08-c39f.jpg"
-            width="206"
-            height="206"
-            data-w="2048"
-            data-h="2048"
-            alt="2025-09-08-c39f.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/2025-09-08-c949.jpg"
-            width="206"
-            height="206"
-            data-w="2048"
-            data-h="2048"
-            alt="2025-09-08-c949.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/2025-09-08-b805.jpg"
-            width="206"
-            height="206"
-            data-w="2048"
-            data-h="2048"
-            alt="2025-09-08-b805.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/2025-09-08-d30b.jpg"
-            width="206"
-            height="206"
-            data-w="4096"
-            data-h="4096"
-            alt="2025-09-08-d30b.jpg"
-            loading="lazy"
-          />
-        </div>
-        <div class="jg-row">
-          <img
-            src="https://p13i.io/assets/2025-09-08-ff7d.jpg"
-            width="206"
-            height="206"
-            data-w="1742"
-            data-h="1742"
-            alt="2025-09-08-ff7d.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/2025-09-08-c57a.jpg"
-            width="206"
-            height="206"
-            data-w="1600"
-            data-h="1600"
-            alt="2025-09-08-c57a.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/2025-09-08-4401.jpg"
-            width="206"
-            height="206"
-            data-w="2048"
-            data-h="2048"
-            alt="2025-09-08-4401.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/2025-09-08-5917.jpg"
-            width="206"
-            height="206"
-            data-w="3024"
-            data-h="3024"
-            alt="2025-09-08-5917.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/2025-09-08-30ee.jpg"
-            width="206"
-            height="206"
-            data-w="1794"
-            data-h="1794"
-            alt="2025-09-08-30ee.jpg"
-            loading="lazy"
-          />
-        </div>
-        <div class="jg-row">
-          <img
-            src="https://p13i.io/assets/pix/2025-09-09-acc0.jpg"
-            width="505"
-            height="122"
-            data-w="4096"
-            data-h="988"
-            alt="2025-09-09-acc0.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/pix/2025-09-09-0dd5.jpg"
-            width="653"
-            height="122"
-            data-w="6000"
-            data-h="1118"
-            alt="2025-09-09-0dd5.jpg"
-            loading="lazy"
-          />
-        </div>
-        <div class="jg-row">
-          <img
-            src="https://p13i.io/assets/pix/2025-09-09-6f59.jpg"
-            width="201"
-            height="201"
-            data-w="750"
-            data-h="750"
-            alt="2025-09-09-6f59.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/pix/2025-09-09-fbe9.jpg"
-            width="302"
-            height="201"
-            data-w="3000"
-            data-h="2000"
-            alt="2025-09-09-fbe9.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/pix/2025-09-09-6108.jpg"
-            width="302"
-            height="201"
-            data-w="3000"
-            data-h="1996"
-            alt="2025-09-09-6108.jpg"
-            loading="lazy"
-          />
-          <img
-            src="https://p13i.io/assets/2025-09-12-802f.jpg"
-            width="268"
-            height="201"
-            data-w="1600"
-            data-h="1200"
-            alt="2025-09-12-802f.jpg"
-            loading="lazy"
-          />
-        </div>
-      </div>
+<style>
+  :root {
+    --jg-spacing: 42px;
+    --jg-max-width: 1200px;
+  }
+  html,
+  body {
+    height: 100%;
+    margin: 0;
+    font-family:
+      system-ui,
+      -apple-system,
+      Segoe UI,
+      Roboto,
+      "Helvetica Neue",
+      Arial;
+  }
+  .jg-wrap {
+    max-width: var(--jg-max-width);
+    margin: 20px auto;
+    padding: 12px;
+    box-sizing: border-box;
+  }
+  .jg-row {
+    display: flex;
+    gap: var(--jg-spacing);
+    margin-bottom: var(--jg-spacing);
+    align-items: stretch;
+  }
+  .jg-row:last-child {
+    margin-bottom: 0;
+  }
+  .jg-row img {
+    display: block;
+    object-fit: cover;
+    --intrinsic-w: auto;
+    --intrinsic-h: auto;
+  }
+  /* make images non-selectable while dragging */
+  .jg-row img {
+    user-select: none;
+    -webkit-user-drag: none;
+  }
+</style>
+<div class="jg-wrap">
+  <!-- Server-side fallback rows (JS will reflow into responsive layout at runtime) -->
+  <div id="justified-gallery-container">
+    <div class="jg-row">
+      <img
+        src="https://p13i.io/assets/pix/IMG_7561-EFFECTS.jpg"
+        width="330"
+        height="248"
+        data-w="4032"
+        data-h="3024"
+        alt="IMG_7561-EFFECTS.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://user-images.githubusercontent.com/13140065/155825868-6ada81bf-69c0-404e-ad28-41fec88c3781.jpg"
+        width="248"
+        height="248"
+        data-w="512"
+        data-h="512"
+        alt="155825868-6ada81bf-69c0-404e-ad28-41fec88c3781.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://user-images.githubusercontent.com/13140065/155815967-0968cbf1-2d06-470a-9fc2-7d3b88493cd9.jpg"
+        width="248"
+        height="248"
+        data-w="512"
+        data-h="512"
+        alt="155815967-0968cbf1-2d06-470a-9fc2-7d3b88493cd9.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://user-images.githubusercontent.com/13140065/155812212-3cf879df-b300-4c53-aacb-b30caa926221.jpg"
+        width="248"
+        height="248"
+        data-w="512"
+        data-h="512"
+        alt="155812212-3cf879df-b300-4c53-aacb-b30caa926221.jpg"
+        loading="lazy"
+      />
     </div>
-    <script>
-      (function () {
-        const SPACING = 42;
-        const TARGET_ROW_HEIGHT = 250;
-        const MIN_ROW_HEIGHT = 120;
-        const MAX_ROW_HEIGHT = 400;
+    <div class="jg-row">
+      <img
+        src="https://raw.githubusercontent.com/p13i/assets/main/2024-12-20-607c.jpg"
+        width="206"
+        height="206"
+        data-w="1600"
+        data-h="1600"
+        alt="2024-12-20-607c.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/2024-12-21-4c7b.jpg"
+        width="206"
+        height="206"
+        data-w="3000"
+        data-h="3000"
+        alt="2024-12-21-4c7b.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/2024-12-21-df84.jpg"
+        width="206"
+        height="206"
+        data-w="1600"
+        data-h="1600"
+        alt="2024-12-21-df84.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/2024-12-21-7019.jpg"
+        width="206"
+        height="206"
+        data-w="2048"
+        data-h="2048"
+        alt="2024-12-21-7019.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/pix/2024-12-22-58af.jpg"
+        width="206"
+        height="206"
+        data-w="2048"
+        data-h="2048"
+        alt="2024-12-22-58af.jpg"
+        loading="lazy"
+      />
+    </div>
+    <div class="jg-row">
+      <img
+        src="https://p13i.io/assets/pix/2024-12-22-5b4d.jpg"
+        width="206"
+        height="206"
+        data-w="2048"
+        data-h="2048"
+        alt="2024-12-22-5b4d.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/pix/2024-12-22-f17f.jpg"
+        width="206"
+        height="206"
+        data-w="2840"
+        data-h="2840"
+        alt="2024-12-22-f17f.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/2025-02-01-33c3.jpg"
+        width="206"
+        height="206"
+        data-w="2048"
+        data-h="2048"
+        alt="2025-02-01-33c3.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/2025-02-12-3680.jpg"
+        width="206"
+        height="206"
+        data-w="3024"
+        data-h="3024"
+        alt="2025-02-12-3680.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/2025-02-27-f1d1.jpg"
+        width="206"
+        height="206"
+        data-w="2587"
+        data-h="2587"
+        alt="2025-02-27-f1d1.jpg"
+        loading="lazy"
+      />
+    </div>
+    <div class="jg-row">
+      <img
+        src="https://p13i.io/assets/2025-04-19-4940.jpg"
+        width="206"
+        height="206"
+        data-w="2048"
+        data-h="2048"
+        alt="2025-04-19-4940.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/2025-05-25-8df0.jpg"
+        width="206"
+        height="206"
+        data-w="1600"
+        data-h="1600"
+        alt="2025-05-25-8df0.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/2025-05-25-0810.jpg"
+        width="206"
+        height="206"
+        data-w="2048"
+        data-h="2048"
+        alt="2025-05-25-0810.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/2025-05-25-5342.jpg"
+        width="206"
+        height="206"
+        data-w="1911"
+        data-h="1911"
+        alt="2025-05-25-5342.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/2025-06-19-5414.jpg"
+        width="206"
+        height="206"
+        data-w="2900"
+        data-h="2900"
+        alt="2025-06-19-5414.jpg"
+        loading="lazy"
+      />
+    </div>
+    <div class="jg-row">
+      <img
+        src="https://p13i.io/assets/2025-08-21-3834.jpg"
+        width="267"
+        height="200"
+        data-w="3000"
+        data-h="2250"
+        alt="2025-08-21-3834.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/2025-08-21-22ae.jpg"
+        width="891"
+        height="200"
+        data-w="2048"
+        data-h="461"
+        alt="2025-08-21-22ae.jpg"
+        loading="lazy"
+      />
+    </div>
+    <div class="jg-row">
+      <img
+        src="https://p13i.io/assets/2025-09-08-3a6f.jpg"
+        width="206"
+        height="206"
+        data-w="1600"
+        data-h="1600"
+        alt="2025-09-08-3a6f.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/2025-09-08-445c.jpg"
+        width="206"
+        height="206"
+        data-w="2048"
+        data-h="2048"
+        alt="2025-09-08-445c.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/2025-09-08-4c03.jpg"
+        width="206"
+        height="206"
+        data-w="2055"
+        data-h="2055"
+        alt="2025-09-08-4c03.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/2025-09-08-4c61.jpg"
+        width="206"
+        height="206"
+        data-w="2048"
+        data-h="2048"
+        alt="2025-09-08-4c61.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/2025-09-08-6c8e.jpg"
+        width="206"
+        height="206"
+        data-w="1600"
+        data-h="1600"
+        alt="2025-09-08-6c8e.jpg"
+        loading="lazy"
+      />
+    </div>
+    <div class="jg-row">
+      <img
+        src="https://p13i.io/assets/2025-09-08-8baf.jpg"
+        width="206"
+        height="206"
+        data-w="2545"
+        data-h="2545"
+        alt="2025-09-08-8baf.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/2025-09-08-a417.jpg"
+        width="208"
+        height="206"
+        data-w="2212"
+        data-h="2196"
+        alt="2025-09-08-a417.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/2025-09-08-0b70.jpg"
+        width="206"
+        height="206"
+        data-w="1600"
+        data-h="1600"
+        alt="2025-09-08-0b70.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/2025-09-08-11ff.jpg"
+        width="206"
+        height="206"
+        data-w="2048"
+        data-h="2048"
+        alt="2025-09-08-11ff.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/2025-09-08-61eb.jpg"
+        width="206"
+        height="206"
+        data-w="2048"
+        data-h="2048"
+        alt="2025-09-08-61eb.jpg"
+        loading="lazy"
+      />
+    </div>
+    <div class="jg-row">
+      <img
+        src="https://p13i.io/assets/2025-09-08-39e1.jpg"
+        width="206"
+        height="206"
+        data-w="2458"
+        data-h="2458"
+        alt="2025-09-08-39e1.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/2025-09-08-c39f.jpg"
+        width="206"
+        height="206"
+        data-w="2048"
+        data-h="2048"
+        alt="2025-09-08-c39f.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/2025-09-08-c949.jpg"
+        width="206"
+        height="206"
+        data-w="2048"
+        data-h="2048"
+        alt="2025-09-08-c949.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/2025-09-08-b805.jpg"
+        width="206"
+        height="206"
+        data-w="2048"
+        data-h="2048"
+        alt="2025-09-08-b805.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/2025-09-08-d30b.jpg"
+        width="206"
+        height="206"
+        data-w="4096"
+        data-h="4096"
+        alt="2025-09-08-d30b.jpg"
+        loading="lazy"
+      />
+    </div>
+    <div class="jg-row">
+      <img
+        src="https://p13i.io/assets/2025-09-08-ff7d.jpg"
+        width="206"
+        height="206"
+        data-w="1742"
+        data-h="1742"
+        alt="2025-09-08-ff7d.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/2025-09-08-c57a.jpg"
+        width="206"
+        height="206"
+        data-w="1600"
+        data-h="1600"
+        alt="2025-09-08-c57a.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/2025-09-08-4401.jpg"
+        width="206"
+        height="206"
+        data-w="2048"
+        data-h="2048"
+        alt="2025-09-08-4401.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/2025-09-08-5917.jpg"
+        width="206"
+        height="206"
+        data-w="3024"
+        data-h="3024"
+        alt="2025-09-08-5917.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/2025-09-08-30ee.jpg"
+        width="206"
+        height="206"
+        data-w="1794"
+        data-h="1794"
+        alt="2025-09-08-30ee.jpg"
+        loading="lazy"
+      />
+    </div>
+    <div class="jg-row">
+      <img
+        src="https://p13i.io/assets/pix/2025-09-09-acc0.jpg"
+        width="505"
+        height="122"
+        data-w="4096"
+        data-h="988"
+        alt="2025-09-09-acc0.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/pix/2025-09-09-0dd5.jpg"
+        width="653"
+        height="122"
+        data-w="6000"
+        data-h="1118"
+        alt="2025-09-09-0dd5.jpg"
+        loading="lazy"
+      />
+    </div>
+    <div class="jg-row">
+      <img
+        src="https://p13i.io/assets/pix/2025-09-09-6f59.jpg"
+        width="201"
+        height="201"
+        data-w="750"
+        data-h="750"
+        alt="2025-09-09-6f59.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/pix/2025-09-09-fbe9.jpg"
+        width="302"
+        height="201"
+        data-w="3000"
+        data-h="2000"
+        alt="2025-09-09-fbe9.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/pix/2025-09-09-6108.jpg"
+        width="302"
+        height="201"
+        data-w="3000"
+        data-h="1996"
+        alt="2025-09-09-6108.jpg"
+        loading="lazy"
+      />
+      <img
+        src="https://p13i.io/assets/2025-09-12-802f.jpg"
+        width="268"
+        height="201"
+        data-w="1600"
+        data-h="1200"
+        alt="2025-09-12-802f.jpg"
+        loading="lazy"
+      />
+    </div>
+  </div>
+</div>
+<script>
+  (function () {
+    const SPACING = 42;
+    const TARGET_ROW_HEIGHT = 250;
+    const MIN_ROW_HEIGHT = 120;
+    const MAX_ROW_HEIGHT = 400;
 
-        function gatherImgs(container) {
-          // collect all imgs with data-w,data-h in document order
-          const imgs = Array.from(
-            container.querySelectorAll(
-              "img[data-w][data-h]"
-            )
+    function gatherImgs(container) {
+      // collect all imgs with data-w,data-h in document order
+      const imgs = Array.from(
+        container.querySelectorAll("img[data-w][data-h]")
+      );
+      return imgs.map((img) => {
+        return {
+          el: img,
+          iw: parseInt(img.getAttribute("data-w"), 10),
+          ih: parseInt(img.getAttribute("data-h"), 10),
+          ratio:
+            parseInt(img.getAttribute("data-w"), 10) /
+            parseInt(img.getAttribute("data-h"), 10)
+        };
+      });
+    }
+
+    function packRowsForWidth(imgs, containerWidth) {
+      const rows = [];
+      let row = [];
+      let sumRatio = 0;
+      for (const im of imgs) {
+        row.push(im);
+        sumRatio += im.ratio;
+        const totalSpacing = SPACING * (row.length - 1);
+        const expectedWidth =
+          sumRatio * TARGET_ROW_HEIGHT + totalSpacing;
+        if (expectedWidth >= containerWidth) {
+          let rowH =
+            (containerWidth - totalSpacing) / sumRatio;
+          rowH = Math.max(
+            MIN_ROW_HEIGHT,
+            Math.min(MAX_ROW_HEIGHT, rowH)
           );
-          return imgs.map((img) => {
-            return {
-              el: img,
-              iw: parseInt(img.getAttribute("data-w"), 10),
-              ih: parseInt(img.getAttribute("data-h"), 10),
-              ratio:
-                parseInt(img.getAttribute("data-w"), 10) /
-                parseInt(img.getAttribute("data-h"), 10)
-            };
-          });
+          rows.push({ row: row.slice(), height: rowH });
+          row = [];
+          sumRatio = 0;
         }
-
-        function packRowsForWidth(imgs, containerWidth) {
-          const rows = [];
-          let row = [];
-          let sumRatio = 0;
-          for (const im of imgs) {
-            row.push(im);
-            sumRatio += im.ratio;
-            const totalSpacing = SPACING * (row.length - 1);
-            const expectedWidth =
-              sumRatio * TARGET_ROW_HEIGHT + totalSpacing;
-            if (expectedWidth >= containerWidth) {
-              let rowH =
-                (containerWidth - totalSpacing) / sumRatio;
-              rowH = Math.max(
-                MIN_ROW_HEIGHT,
-                Math.min(MAX_ROW_HEIGHT, rowH)
-              );
-              rows.push({ row: row.slice(), height: rowH });
-              row = [];
-              sumRatio = 0;
-            }
-          }
-          if (row.length) {
-            const totalSpacing = SPACING * (row.length - 1);
-            const rowH = Math.min(
-              TARGET_ROW_HEIGHT,
-              Math.max(
-                MIN_ROW_HEIGHT,
-                sumRatio > 0
-                  ? (containerWidth - totalSpacing) /
-                      sumRatio
-                  : TARGET_ROW_HEIGHT
-              )
-            );
-            rows.push({ row: row.slice(), height: rowH });
-          }
-          return rows;
-        }
-
-        function clearChildren(el) {
-          while (el.firstChild)
-            el.removeChild(el.firstChild);
-        }
-
-        function relayout() {
-          const container = document.getElementById(
-            "justified-gallery-container"
-          );
-          if (!container) return;
-          // pull all imgs (they are initially inside server-side rows)
-          const imgs = gatherImgs(container);
-          if (!imgs.length) return;
-          const containerWidth = Math.max(
-            200,
-            container.clientWidth
-          ); // avoid degenerate widths
-          const rows = packRowsForWidth(
-            imgs,
-            containerWidth
-          );
-
-          // build new DOM
-          clearChildren(container);
-          for (let i = 0; i < rows.length; ++i) {
-            const r = rows[i];
-            const rowDiv = document.createElement("div");
-            rowDiv.className = "jg-row";
-            rowDiv.style.display = "flex";
-            rowDiv.style.gap = SPACING + "px";
-            rowDiv.style.marginBottom = SPACING + "px";
-            for (let j = 0; j < r.row.length; ++j) {
-              const im = r.row[j];
-              const w = Math.max(
-                1,
-                Math.round(im.ratio * r.height)
-              );
-              const h = Math.max(1, Math.round(r.height));
-              // re-use existing img element (preserves src, lazy status)
-              const imgEl = im.el;
-              imgEl.style.width = w + "px";
-              imgEl.style.height = h + "px";
-              imgEl.setAttribute("width", String(w));
-              imgEl.setAttribute("height", String(h));
-              rowDiv.appendChild(imgEl);
-            }
-            container.appendChild(rowDiv);
-          }
-        }
-
-        // debounce helper
-        function debounce(fn, wait) {
-          let t = null;
-          return function () {
-            const args = arguments;
-            clearTimeout(t);
-            t = setTimeout(
-              () => fn.apply(null, args),
-              wait
-            );
-          };
-        }
-
-        // Run after DOM ready and on resize
-        document.addEventListener(
-          "DOMContentLoaded",
-          relayout
+      }
+      if (row.length) {
+        const totalSpacing = SPACING * (row.length - 1);
+        const rowH = Math.min(
+          TARGET_ROW_HEIGHT,
+          Math.max(
+            MIN_ROW_HEIGHT,
+            sumRatio > 0
+              ? (containerWidth - totalSpacing) / sumRatio
+              : TARGET_ROW_HEIGHT
+          )
         );
-        window.addEventListener(
-          "resize",
-          debounce(relayout, 120)
-        );
-        // also run just in case images are cached
-        window.addEventListener("load", relayout);
-      })();
-    </script>
-  </body>
-</html>
+        rows.push({ row: row.slice(), height: rowH });
+      }
+      return rows;
+    }
+
+    function clearChildren(el) {
+      while (el.firstChild) el.removeChild(el.firstChild);
+    }
+
+    function relayout() {
+      const container = document.getElementById(
+        "justified-gallery-container"
+      );
+      if (!container) return;
+      // pull all imgs (they are initially inside server-side rows)
+      const imgs = gatherImgs(container);
+      if (!imgs.length) return;
+      const containerWidth = Math.max(
+        200,
+        container.clientWidth
+      ); // avoid degenerate widths
+      const rows = packRowsForWidth(imgs, containerWidth);
+
+      // build new DOM
+      clearChildren(container);
+      for (let i = 0; i < rows.length; ++i) {
+        const r = rows[i];
+        const rowDiv = document.createElement("div");
+        rowDiv.className = "jg-row";
+        rowDiv.style.display = "flex";
+        rowDiv.style.gap = SPACING + "px";
+        rowDiv.style.marginBottom = SPACING + "px";
+        for (let j = 0; j < r.row.length; ++j) {
+          const im = r.row[j];
+          const w = Math.max(
+            1,
+            Math.round(im.ratio * r.height)
+          );
+          const h = Math.max(1, Math.round(r.height));
+          // re-use existing img element (preserves src, lazy status)
+          const imgEl = im.el;
+          imgEl.style.width = w + "px";
+          imgEl.style.height = h + "px";
+          imgEl.setAttribute("width", String(w));
+          imgEl.setAttribute("height", String(h));
+          rowDiv.appendChild(imgEl);
+        }
+        container.appendChild(rowDiv);
+      }
+    }
+
+    // debounce helper
+    function debounce(fn, wait) {
+      let t = null;
+      return function () {
+        const args = arguments;
+        clearTimeout(t);
+        t = setTimeout(() => fn.apply(null, args), wait);
+      };
+    }
+
+    // Run after DOM ready and on resize
+    document.addEventListener("DOMContentLoaded", relayout);
+    window.addEventListener(
+      "resize",
+      debounce(relayout, 120)
+    );
+    // also run just in case images are cached
+    window.addEventListener("load", relayout);
+  })();
+</script>

--- a/scripts/make_web_tiles.py
+++ b/scripts/make_web_tiles.py
@@ -218,7 +218,6 @@ def MakeWebTiles(image_urls: List[str]) -> str:
         "  <style>",
         css,
         "  </style>",
-
         "  <div class='jg-wrap'>",
         "    <!-- Server-side fallback rows (JS will reflow into responsive layout at runtime) -->",
         "    <div id='justified-gallery-container'>",
@@ -227,7 +226,7 @@ def MakeWebTiles(image_urls: List[str]) -> str:
         "  </div>",
         "  <script>",
         js,
-        "  </script>"
+        "  </script>",
     ]
 
     return "\n".join(html_out)


### PR DESCRIPTION
This pull request applies NPM's `prettier` formatting changes to the codebase at 5eaa99105e645a0e20b10c0c320965c275d2ddf8.