### PR TITLE
ci: stop auto-opening prettier formatting PRs

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -19,27 +19,3 @@ jobs:
         run:
           git diff && exit $(git status --porcelain=v1
           2>/dev/null | wc -l)
-
-      - name: Create Pull Request
-        id: cpr
-        uses: peter-evans/create-pull-request@v3
-        if: ${{ failure() }}
-        with:
-          token: ${{ secrets.WORKFLOW_TOKEN }}
-          commit-message:
-            Apply prettier to ${{ github.ref_name }}
-          title: Apply prettier to ${{ github.ref_name }}
-          branch: prettier-${{ github.run_number }}
-          body:
-            This pull request applies NPM's `prettier`
-            formatting changes to the codebase at ${{
-            github.sha }}.
-          labels: auto-generated
-          reviewers: ${{ github.actor }}
-
-      - name: Store pull request number
-        if: ${{ failure() }}
-        run:
-          echo "PR_NUMBER=${{
-          steps.cpr.outputs.pull-request-number }}" >>
-          $GITHUB_ENV


### PR DESCRIPTION
Removes the workflow steps that auto-create `prettier-<run>` branches and PRs on lint failure (the source of the 425 auto-generated branches, and now failing with 'could not read Username' because the WORKFLOW_TOKEN secret is expired). The prettier lint check is retained; run prettier locally to fix formatting. Reversible.