### PR TITLE
Refine homepage research and engineering introduction

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: Pramod Kotipalli
-subtitle: Masters candidate, Stanford CS
+subtitle: Software engineer and computer science researcher
 url: "https://p13i.io"
 
 # Site configurations

--- a/_data/navbar.yml
+++ b/_data/navbar.yml
@@ -3,6 +3,11 @@
   target: _self
   category: research
 
+- display: "Engineering ⚙️"
+  href: /engineering/
+  target: _self
+  category: engineering
+
 - display: "Writing 📝"
   href: /writing/
   target: _self

--- a/_layouts/index.md
+++ b/_layouts/index.md
@@ -5,15 +5,19 @@ layout: base
 <div class="row index">
   <div class="col-12">
     <hr />
-    <h3 class="hey">hey there! 😁</h3>
+    <h1 class="hey">Hi, I'm Pramod.</h1>
     <hr />
   </div>
   <div class="col-12 col-md-4 col-lg-3">
     <div class="row">
-      <div class="col-md-12 col-sm-4 col-4">
-        <img src="{{ site.data.images.headshot.src }}" width="100%" />
+      <div class="col-12 col-sm-4 col-md-12">
+        <img
+          src="{{ site.data.images.headshot.src }}"
+          alt="Portrait of Pramod Kotipalli"
+          width="100%"
+        />
       </div>
-      <div class="col-md-12 col-sm-8 col-8">
+      <div class="col-12 col-sm-8 col-md-12">
         <div class="d-sm-none d-none d-md-inline"><hr /></div>
         {{ content }}
         <hr />
@@ -22,9 +26,12 @@ layout: base
     </div>
   </div>
   <div class="col-12 col-md-8 col-lg-9">
+    <h2>Research and engineering</h2>
     {% for post in site.posts %}
         {% if post.featured %}
+          {% if post.categories contains "research" or post.categories contains "engineering" %}
             {% include _post_card.html post=post %}
+          {% endif %}
         {% endif %}
     {% endfor %}
   </div>

--- a/index.md
+++ b/index.md
@@ -1,5 +1,24 @@
 ---
 layout: index
+description:
+  Software engineer and computer science researcher working
+  across machine learning, distributed systems, and
+  human-computer interaction.
 ---
 
-brb gonna get my phd
+I'm a software engineer and computer science researcher. My
+work spans machine learning, distributed systems, and
+human-computer interaction.
+
+I studied computer science at Georgia Tech and Stanford,
+then spent three years building high-scale systems at
+Google. Recently, I have been building and evaluating
+machine-learning systems, from distributed model training to
+on-device inference.
+
+I'm especially interested in how intelligent systems work
+and why models make the choices they do.
+
+Start with my [research](/research/),
+[engineering work](/engineering/), [writing](/writing/), or
+[CV](/cv/).

--- a/index.md
+++ b/index.md
@@ -6,19 +6,4 @@ description:
   human-computer interaction.
 ---
 
-I'm a software engineer and computer science researcher. My
-work spans machine learning, distributed systems, and
-human-computer interaction.
-
-I studied computer science at Georgia Tech and Stanford,
-then spent three years building high-scale systems at
-Google. Recently, I have been building and evaluating
-machine-learning systems, from distributed model training to
-on-device inference.
-
-I'm especially interested in how intelligent systems work
-and why models make the choices they do.
-
-Start with my [research](/research/),
-[engineering work](/engineering/), [writing](/writing/), or
-[CV](/cv/).
+I’m a software engineer and computer science researcher.


### PR DESCRIPTION
## Summary

- replace the stale student-status homepage copy with a current, organization-neutral introduction grounded in existing résumé and application materials
- add Engineering to the primary navigation and prioritize existing research and engineering posts on the homepage
- improve the homepage heading, headshot alternative text, and small-screen stacking
- update the site subtitle to match the current introduction

## Impact

The homepage now gives visitors a concise path into Pramod's research, engineering work, writing, and CV without mentioning or visibly targeting a specific application.

## Validation

- `npx -y prettier --check --print-width 60 --trailing-comma=none --prose-wrap always index.md _layouts/index.md _data/navbar.yml _config.yml` — passed
- `git diff --check` — passed
- full `make lint` — completed after providing its missing Python dependencies; it also produced four unrelated baseline-generated diffs, which were restored and are not part of this PR
- user-scoped Jekyll 4 fallback build with the repository plugins preloaded — passed and generated the full site
- local HTTP checks for `/`, `/research/`, `/engineering/`, `/writing/`, `/cv/`, and `/posts/2023/08/cc-simulations/` — all returned 200
- desktop render inspected at 1440×1100
- mobile emulation at 390×844 — no horizontal overflow (`scrollWidth: 390`)

## Not tested

The repository's prescribed Ruby 2.4 Docker build could not run because the Docker daemon repeatedly timed out resolving `registry-1.docker.io` while fetching `ruby:2.4`; the local Jekyll fallback covered full-site generation instead.

---

Written by Codex